### PR TITLE
fix: Adds contents write permissions to vimdoc and luadoc workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,9 @@ on:
       - "doc/**"
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   vimdoc:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add permission for vimdoc and luadoc workflow to write.

## Related issues

<!-- Link any related issues: Fixes #123, Closes #456 -->

## Checklist

- [ ] Code is formatted (`make format`)
- [ ] Linting passes (`make lint`)
- [ ] Tests pass (`make test`)
- [ ] New public functions have LuaCATS annotations
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
