### PR TITLE
chore: Update renovate and docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,27 +52,10 @@ jobs:
         with:
           luaVersion: "5.1"
 
-      - uses: leafo/gh-actions-luarocks@v6
-
       - name: Generate API docs
         run: |
           mkdir -p doc/api
-          echo "# API Reference" > doc/api/README.md
-          echo "" >> doc/api/README.md
-          echo "Auto-generated from LuaCATS annotations." >> doc/api/README.md
-          echo "" >> doc/api/README.md
-
-          for f in lua/pr-description/*.lua; do
-            module=$(basename "$f" .lua)
-            echo "## pr-description.${module}" >> doc/api/README.md
-            echo "" >> doc/api/README.md
-            # Extract @brief blocks
-            sed -n '/---@brief \[\[/,/---@brief \]\]/{ /---@brief/d; s/^--- //; s/^---//; p; }' "$f" >> doc/api/README.md
-            echo "" >> doc/api/README.md
-            # Extract function signatures with their doc comments
-            grep -B 20 "^function M\." "$f" | grep "^---" | sed 's/^--- //' | sed 's/^---//' >> doc/api/README.md
-            echo "" >> doc/api/README.md
-          done
+          lua scripts/generate-api-docs.lua
 
       - name: Create PR for API docs changes
         id: api-docs-pr

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,8 +16,10 @@ repos:
       - id: stylua-github
         args: [--config-path=stylua.toml]
 
-  - repo: https://github.com/luarocks/luacheck
-    rev: v1.2.0
+  - repo: https://github.com/lunarmodules/luacheck
+    # Pinned to master (post-v1.2.0) for Lua 5.5 compatibility; v1.2.0 crashes
+    # on Lua 5.5 because standards.lua reassigns a const for-loop variable.
+    rev: f47ad699b5aab8eba5494a2b63e26c24dbf486ce
     hooks:
       - id: luacheck
         args: [--config=.luacheckrc]

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,4 @@ check: lint
 
 docs:
 	@lua scripts/update-readme-config.lua
+	@lua scripts/generate-api-docs.lua

--- a/doc/api/README.md
+++ b/doc/api/README.md
@@ -1,140 +1,7 @@
 # API Reference
 
-Auto-generated from LuaCATS annotations.
-
-## pr-description.config
-
-Configuration for pr-description.nvim.
-
-@field strip_commit_prefix? boolean Strip conventional commit prefix/scope from output (default: true)
-@type PrDescriptionConfig
-@type PrDescriptionConfig
-Apply user configuration.
-@param opts? PrDescriptionConfig
-
-## pr-description.formatter
-
-Markdown generation for PR descriptions.
-
-Formats categorized commits and file changes into a well-structured
-markdown document suitable for GitHub PRs or GitLab MRs. Includes
-emoji indicators, collapsible sections, and statistics.
-
-Add the summary placeholder section to the output.
-@param lines string[] The output lines table (modified in place)
-Add categorized commit sections to the output.
-Only adds sections for categories that have commits.
-@param lines string[] The output lines table (modified in place)
-@param categories CommitCategories The categorized commits
-Determine which logical group a file belongs to based on its path.
-Groups files by top-level directory or special patterns (tests, docs, config).
-@param filepath string The file path
-@return string group The group name (e.g., "Root", "Tests", "Documentation")
-@class FileInfo
-@field path string The file path
-@field symbol string Emoji status symbol
-@field stats string Formatted stats string (e.g., " (+10/-5)")
-Group files by their logical directory/category.
-@param file_list FileChange[] List of file changes
-@param file_stats table<string, FileStats> Map of filepath to statistics
-@return table<string, FileInfo[]> groups Files grouped by category name
-Sort group names by predefined priority (Root first, Tests/Docs last).
-@param groups table<string, FileInfo[]> The groups to sort
-@return string[] sorted_names Group names in sorted order
-Add the file changes section to the output.
-Lists files grouped by category with statistics.
-@param lines string[] The output lines table (modified in place)
-@param file_groups table<string, FileInfo[]> Files grouped by category
-@param file_stats table<string, FileStats> Map of filepath to statistics
-@class DescriptionStats
-@field total_files number Total number of files changed
-@field total_insertions number Total lines inserted
-@field total_deletions number Total lines deleted
-@field total_commits number Total number of commits
-@field branch string Current branch name
-@field base_branch string Base branch name
-Add the footer section with summary statistics.
-@param lines string[] The output lines table (modified in place)
-@param stats DescriptionStats Summary statistics
-Generate the complete PR/MR description.
-@param categories CommitCategories Categorized commits
-@param file_groups table<string, FileInfo[]> Files grouped by category
-@param file_stats table<string, FileStats> Map of filepath to statistics
-@param stats DescriptionStats Summary statistics
-@return string description The complete markdown description
-
-## pr-description.git
-
-Git operations for PR description generation.
-
-Provides functions for interacting with git to extract repository information,
-branch details, commit history, and file change statistics.
-
-@module "pr-description.git"
-@brief [[
-Git operations for PR description generation.
-
-Provides functions for interacting with git to extract repository information,
-branch details, commit history, and file change statistics.
-@brief ]]
-Check if current directory is inside a git repository.
-@return boolean|nil ok True if in a git repository, nil on error
-@return string|nil error Error message if not in a repository
-Get the name of the current git branch.
-@return string|nil branch The current branch name
-@return string|nil error Error message if branch could not be determined
-Detect the base branch to compare against.
-Tries origin/HEAD first, then falls back to origin/main, origin/master,
-and finally local main/master branches.
-@return string|nil base_branch The detected base branch (e.g., "origin/main")
-@return string|nil error Error message if no base branch could be detected
-Get the remote origin URL.
-@return string url The remote origin URL (may be empty if not configured)
-Fetch latest refs from origin to ensure accurate comparisons.
-@return boolean ok True if fetch succeeded or was skipped gracefully
-Find the merge-base (fork point) between two branches.
-@param base_branch string The base branch
-@param branch string The current branch
-@return string|nil merge_base The merge-base commit hash, or nil on error
-@return string|nil error Error message if merge-base failed
-Get commit messages between base branch and current branch.
-Uses merge-base to only include commits unique to the current branch.
-@param base_branch string The base branch to compare from
-@param branch string The current branch to compare to
-@return string[]|nil commits List of commit lines (hash + subject), or nil on error
-@return string|nil error Error message if git log failed
-Get commit messages from a known merge-base to branch tip.
-@param merge_base string The merge-base commit hash
-@param branch string The current branch to compare to
-@return string[]|nil commits List of commit lines (hash + subject), or nil on error
-@return string|nil error Error message if git log failed
-Get file change status (added, modified, deleted) between branches.
-Uses merge-base for accurate comparison.
-@param base_branch string The base branch to compare from
-@param branch string The current branch to compare to
-@return string[] changes List of file changes in "status\tfilepath" format
-Get file change status from a known merge-base to branch tip.
-@param merge_base string The merge-base commit hash or branch ref
-@param branch string The current branch to compare to
-@return string[] changes List of file changes in "status\tfilepath" format
-Get human-readable file statistics (insertions/deletions summary).
-Uses merge-base for accurate comparison.
-@param base_branch string The base branch to compare from
-@param branch string The current branch to compare to
-@return string stats The git diff --stat output as a single string
-Get human-readable file statistics from a known merge-base to branch tip.
-@param merge_base string The merge-base commit hash or branch ref
-@param branch string The current branch to compare to
-@return string stats The git diff --stat output as a single string
-Get machine-readable file statistics (insertions/deletions per file).
-Uses merge-base for accurate comparison.
-@param base_branch string The base branch to compare from
-@param branch string The current branch to compare to
-@return string[] numstat List of lines in "insertions\tdeletions\tfilepath" format
-Get machine-readable file statistics from a known merge-base to branch tip.
-@param merge_base string The merge-base commit hash or branch ref
-@param branch string The current branch to compare to
-@return string[] numstat List of lines in "insertions\tdeletions\tfilepath" format
+Auto-generated from LuaCATS annotations. Do not edit by hand;
+run `make docs` to regenerate.
 
 ## pr-description.init
 
@@ -150,74 +17,231 @@ Usage:
   :PRDescription
   :MRDescription
 
-descriptions by analyzing git commits and file changes. It categorizes commits
-using conventional commit patterns, links issues and tickets, and produces
-markdown-formatted output suitable for GitHub PRs or GitLab MRs.
+### `M.setup(opts)`
 
-Usage:
-  require("pr-description").setup({ jira_base_url = "https://company.atlassian.net/browse" })
-  :PRDescription
-  :MRDescription
-@brief ]]
 Setup pr-description.nvim with user options.
-@param opts? PrDescriptionConfig
-@class GenerateOpts
-@field is_gitlab? boolean Whether this is a GitLab MR (default: false, auto-detected from remote)
-@field to_clipboard? boolean Copy result to clipboard (default: false)
+
+**Parameters:**
+
+- `opts?` (`PrDescriptionConfig`)
+
+### Type: `GenerateOpts`
+
+- `is_gitlab?` (`boolean`) — Whether this is a GitLab MR (default: false, auto-detected from remote)
+- `to_clipboard?` (`boolean`) — Copy result to clipboard (default: false)
+
+### `M.generate_description(opts)`
+
 Generate a PR/MR description from the current branch's commits.
-@param opts? GenerateOpts
-@return string|nil description The generated markdown description, or nil on error
-@return string|nil error Error message if generation failed
 
-## pr-description.links
+**Parameters:**
 
-URL parsing and link generation for PR descriptions.
+- `opts?` (`GenerateOpts`)
 
-Handles parsing of git remote URLs (SSH and HTTPS formats), building
-repository URLs, and generating markdown links for issues, Jira tickets,
-and commit references.
+**Returns:**
 
-@module "pr-description.links"
-@brief [[
-URL parsing and link generation for PR descriptions.
+- `string|nil` — description The generated markdown description, or nil on error
+- `string|nil` — error Error message if generation failed
 
-Handles parsing of git remote URLs (SSH and HTTPS formats), building
-repository URLs, and generating markdown links for issues, Jira tickets,
-and commit references.
-@brief ]]
-Parse a git remote URL into host and path components.
-Supports SSH (git@host:path or ssh://git@host/path) and HTTPS formats.
-@param url string The git remote URL
-@return string|nil host The hostname (e.g., "github.com")
-@return string|nil path The repository path (e.g., "owner/repo")
-Build a full HTTPS repository URL from host and path.
-@param host string|nil The hostname (e.g., "github.com")
-@param path string|nil The repository path (e.g., "owner/repo")
-@return string url The full repository URL, or empty string if host/path is nil
-Check if a host is a GitLab instance.
-@param host string|nil The hostname to check
-@return boolean is_gitlab True if the host contains "gitlab"
-Add markdown links to issue references (e.g., "fixes #123").
-Converts patterns like "fixes #123" to "fixes [#123](repo_url/issues/123)".
-@param text string The text to process
-@param repo_url string The repository base URL
-@param is_gitlab boolean Whether to use GitLab URL format (/-/issues/)
-@return string text The text with issue references converted to links
-Add markdown links to Jira ticket references (e.g., "PROJ-123").
-@param text string The text to process
-@param base_url? string Jira base URL (e.g., "https://company.atlassian.net/browse")
-@return string text The text with Jira tickets converted to links
-Add all supported markdown links (issues and Jira tickets).
-@param text string The text to process
-@param repo_url string The repository base URL
-@param is_gitlab boolean Whether to use GitLab URL format
-@param jira_base_url? string Jira base URL for ticket links
-@return string text The text with all references converted to links
-Create a markdown link to a commit.
-@param hash string The commit hash (short or full)
-@param repo_url string The repository base URL
-@param is_gitlab boolean Whether to use GitLab URL format (/-/commit/)
-@return string link The markdown link, or empty string if repo_url is empty
+## pr-description.config
+
+Configuration for pr-description.nvim.
+
+### Type: `PrDescriptionConfig`
+
+- `auto_detect_platform?` (`boolean`) — Auto-detect GitHub vs GitLab from remote URL (default: true)
+- `confirm_large_pr?` (`boolean`) — Prompt when more than `large_pr_threshold` commits (default: true)
+- `enable_icons?` (`boolean`) — Include icons in final PR/MR pr-description (default: true)
+- `enable_stats_footer?` (`boolean`) — Include stats footer in final PR/MR pr-description (default: true)
+- `fetch_before_generate?` (`boolean`) — Fetch origin before generating to ensure accurate comparison (default: true)
+- `jira_base_url?` (`string`) — Base URL for Jira ticket links (e.g., "https://company.atlassian.net/browse")
+- `large_pr_threshold?` (`number`) — Number of commits before prompting (default: 10)
+- `sections?` (`table<string, string>`) — Override section headers (key = category, value = markdown header)
+- `strip_commit_prefix?` (`boolean`) — Strip conventional commit prefix/scope from output (default: true)
+
+### `M.setup(opts)`
+
+Apply user configuration.
+
+**Parameters:**
+
+- `opts?` (`PrDescriptionConfig`)
+
+## pr-description.git
+
+Git operations for PR description generation.
+
+Provides functions for interacting with git to extract repository information,
+branch details, commit history, and file change statistics.
+
+### `M.check_repo()`
+
+Check if current directory is inside a git repository.
+
+**Returns:**
+
+- `boolean|nil` — ok True if in a git repository, nil on error
+- `string|nil` — error Error message if not in a repository
+
+### `M.get_current_branch()`
+
+Get the name of the current git branch.
+
+**Returns:**
+
+- `string|nil` — branch The current branch name
+- `string|nil` — error Error message if branch could not be determined
+
+### `M.detect_base_branch()`
+
+Detect the base branch to compare against.
+Tries origin/HEAD first, then falls back to origin/main, origin/master,
+and finally local main/master branches.
+
+**Returns:**
+
+- `string|nil` — base_branch The detected base branch (e.g., "origin/main")
+- `string|nil` — error Error message if no base branch could be detected
+
+### `M.get_remote_url()`
+
+Get the remote origin URL.
+
+**Returns:**
+
+- `string` — url The remote origin URL (may be empty if not configured)
+
+### `M.fetch_origin()`
+
+Fetch latest refs from origin to ensure accurate comparisons.
+
+**Returns:**
+
+- `boolean` — ok True if fetch succeeded or was skipped gracefully
+
+### `M.get_merge_base(base_branch, branch)`
+
+Find the merge-base (fork point) between two branches.
+
+**Parameters:**
+
+- `base_branch` (`string`) — The base branch
+- `branch` (`string`) — The current branch
+
+**Returns:**
+
+- `string|nil` — merge_base The merge-base commit hash, or nil on error
+- `string|nil` — error Error message if merge-base failed
+
+### `M.get_commits(base_branch, branch)`
+
+Get commit messages between base branch and current branch.
+Uses merge-base to only include commits unique to the current branch.
+
+**Parameters:**
+
+- `base_branch` (`string`) — The base branch to compare from
+- `branch` (`string`) — The current branch to compare to
+
+**Returns:**
+
+- `string[]|nil` — commits List of commit lines (hash + subject), or nil on error
+- `string|nil` — error Error message if git log failed
+
+### `M.get_commits_from(merge_base, branch)`
+
+Get commit messages from a known merge-base to branch tip.
+
+**Parameters:**
+
+- `merge_base` (`string`) — The merge-base commit hash
+- `branch` (`string`) — The current branch to compare to
+
+**Returns:**
+
+- `string[]|nil` — commits List of commit lines (hash + subject), or nil on error
+- `string|nil` — error Error message if git log failed
+
+### `M.get_file_changes(base_branch, branch)`
+
+Get file change status (added, modified, deleted) between branches.
+Uses merge-base for accurate comparison.
+
+**Parameters:**
+
+- `base_branch` (`string`) — The base branch to compare from
+- `branch` (`string`) — The current branch to compare to
+
+**Returns:**
+
+- `string[]` — changes List of file changes in "status\tfilepath" format
+
+### `M.get_file_changes_from(merge_base, branch)`
+
+Get file change status from a known merge-base to branch tip.
+
+**Parameters:**
+
+- `merge_base` (`string`) — The merge-base commit hash or branch ref
+- `branch` (`string`) — The current branch to compare to
+
+**Returns:**
+
+- `string[]` — changes List of file changes in "status\tfilepath" format
+
+### `M.get_file_stats(base_branch, branch)`
+
+Get human-readable file statistics (insertions/deletions summary).
+Uses merge-base for accurate comparison.
+
+**Parameters:**
+
+- `base_branch` (`string`) — The base branch to compare from
+- `branch` (`string`) — The current branch to compare to
+
+**Returns:**
+
+- `string` — stats The git diff --stat output as a single string
+
+### `M.get_file_stats_from(merge_base, branch)`
+
+Get human-readable file statistics from a known merge-base to branch tip.
+
+**Parameters:**
+
+- `merge_base` (`string`) — The merge-base commit hash or branch ref
+- `branch` (`string`) — The current branch to compare to
+
+**Returns:**
+
+- `string` — stats The git diff --stat output as a single string
+
+### `M.get_file_numstat(base_branch, branch)`
+
+Get machine-readable file statistics (insertions/deletions per file).
+Uses merge-base for accurate comparison.
+
+**Parameters:**
+
+- `base_branch` (`string`) — The base branch to compare from
+- `branch` (`string`) — The current branch to compare to
+
+**Returns:**
+
+- `string[]` — numstat List of lines in "insertions\tdeletions\tfilepath" format
+
+### `M.get_file_numstat_from(merge_base, branch)`
+
+Get machine-readable file statistics from a known merge-base to branch tip.
+
+**Parameters:**
+
+- `merge_base` (`string`) — The merge-base commit hash or branch ref
+- `branch` (`string`) — The current branch to compare to
+
+**Returns:**
+
+- `string[]` — numstat List of lines in "insertions\tdeletions\tfilepath" format
 
 ## pr-description.parser
 
@@ -227,61 +251,369 @@ Parses git commits following the conventional commit specification and
 categorizes them into groups (features, fixes, docs, etc.). Also handles
 parsing of git diff statistics for file change analysis.
 
-  others    — (fallback) Commits not matching any conventional prefix
+### `M.strip_prefix(subject)`
+
 Strip the conventional commit prefix and optional scope from a subject.
 Transforms "feat(auth): add login" to "add login", "fix!: crash" to "crash".
 Returns the subject unchanged if it doesn't match a conventional pattern.
-@param subject string The commit subject line
-@return string stripped The subject without the conventional commit prefix
+
+**Parameters:**
+
+- `subject` (`string`) — The commit subject line
+
+**Returns:**
+
+- `string` — stripped The subject without the conventional commit prefix
+
+### `M.categorize_commit(subject)`
+
 Categorize a commit subject based on conventional commit prefixes.
-@param subject string The commit subject line
-@return string category The category name (e.g., "features", "fixes", "others")
+
+**Parameters:**
+
+- `subject` (`string`) — The commit subject line
+
+**Returns:**
+
+- `string` — category The category name (e.g., "features", "fixes", "others")
+
+### `M.is_breaking_change(subject)`
+
 Check if a commit subject indicates a breaking change.
 Detects "BREAKING CHANGE" text or "!" marker in conventional commits.
-@param subject string The commit subject line
-@return boolean is_breaking True if this is a breaking change
+
+**Parameters:**
+
+- `subject` (`string`) — The commit subject line
+
+**Returns:**
+
+- `boolean` — is_breaking True if this is a breaking change
+
+### `M.parse_commit_line(line)`
+
 Parse a single commit line into hash and subject.
-@param line string A line from `git log --oneline` output
-@return string hash The commit hash
-@return string subject The commit subject message
-@field docs string[] Documentation-only changes
-@field refactor string[] Code restructuring without changing behavior
-@field tests string[] Adding or updating tests
-@field style string[] Formatting, whitespace, or cosmetic changes
-@field chores string[] Maintenance and miscellaneous non-code tasks
-@field ops string[] Operational changes: infrastructure, deployment, CI/CD, monitoring
-@field reverts string[] Commits that revert a previous change
-@field wip string[] Work-in-progress, not ready for review
-@field breaking string[] Commits with BREAKING CHANGE text or ! marker (derived from other categories)
-@field others string[] Commits not matching any conventional commit prefix
-@class ParseCommitsCallbacks
-@field process_subject? fun(subject: string): string Add links to a commit subject
-@field make_commit_link? fun(hash: string): string Create a markdown link for a commit hash
-@field strip_prefix? boolean Strip conventional commit prefix/scope from display text
+
+**Parameters:**
+
+- `line` (`string`) — A line from `git log --oneline` output
+
+**Returns:**
+
+- `string` — hash The commit hash
+- `string` — subject The commit subject message
+
+### Type: `CommitCategories`
+
+- `features` (`string[]`) — New functionality or capabilities
+- `fixes` (`string[]`) — Bug fixes and corrections
+- `perf` (`string[]`) — Performance improvements without changing behavior
+- `docs` (`string[]`) — Documentation-only changes
+- `refactor` (`string[]`) — Code restructuring without changing behavior
+- `tests` (`string[]`) — Adding or updating tests
+- `style` (`string[]`) — Formatting, whitespace, or cosmetic changes
+- `chores` (`string[]`) — Maintenance and miscellaneous non-code tasks
+- `ops` (`string[]`) — Operational changes: infrastructure, deployment, CI/CD, monitoring
+- `reverts` (`string[]`) — Commits that revert a previous change
+- `wip` (`string[]`) — Work-in-progress, not ready for review
+- `breaking` (`string[]`) — Commits with BREAKING CHANGE text or ! marker (derived from other categories)
+- `others` (`string[]`) — Commits not matching any conventional commit prefix
+
+### Type: `ParseCommitsCallbacks`
+
+- `process_subject?` (`fun(subject: string): string`) — Add links to a commit subject
+- `make_commit_link?` (`fun(hash: string): string`) — Create a markdown link for a commit hash
+- `strip_prefix?` (`boolean`) — Strip conventional commit prefix/scope from display text
+
+### `M.parse_commits(commit_lines, callbacks)`
+
 Parse and categorize a list of commit lines.
-@param commit_lines string[] Lines from `git log --oneline` output
-@param callbacks? ParseCommitsCallbacks Optional callbacks for link processing
-@return CommitCategories categories Commits grouped by category
-@class FileStats
-@field insertions number Number of lines added
-@field deletions number Number of lines deleted
+
+**Parameters:**
+
+- `commit_lines` (`string[]`) — Lines from `git log --oneline` output
+- `callbacks?` (`ParseCommitsCallbacks`) — Optional callbacks for link processing
+
+**Returns:**
+
+- `CommitCategories` — categories Commits grouped by category
+
+### Type: `FileStats`
+
+- `insertions` (`number`) — Number of lines added
+- `deletions` (`number`) — Number of lines deleted
+
+### `M.resolve_rename_path(raw)`
+
 Resolve a rename path from git's `{old => new}` notation to the new path.
 Handles formats: `prefix/{old => new}/suffix`, `{old => new}`, `old => new`.
-@param raw string The raw path from git output
-@return string filepath The resolved new file path
+
+**Parameters:**
+
+- `raw` (`string`) — The raw path from git output
+
+**Returns:**
+
+- `string` — filepath The resolved new file path
+
+### `M.parse_file_numstat(lines)`
+
 Parse `git diff --numstat` output into file statistics.
-@param lines string[] Lines from `git diff --numstat` output
-@return table<string, FileStats> stats Map of filepath to insertion/deletion counts
-@class FileChange
-@field status string Single-letter status (A=added, M=modified, D=deleted, R=renamed)
-@field path string The file path
+
+**Parameters:**
+
+- `lines` (`string[]`) — Lines from `git diff --numstat` output
+
+**Returns:**
+
+- `table<string, FileStats>` — stats Map of filepath to insertion/deletion counts
+
+### Type: `FileChange`
+
+- `status` (`string`) — Single-letter status (A=added, M=modified, D=deleted, R=renamed)
+- `path` (`string`) — The file path
+
+### `M.parse_file_changes(lines)`
+
 Parse `git diff --name-status` output into file changes.
-@param lines string[] Lines from `git diff --name-status` output
-@return FileChange[] files List of file changes with status and path
+
+**Parameters:**
+
+- `lines` (`string[]`) — Lines from `git diff --name-status` output
+
+**Returns:**
+
+- `FileChange[]` — files List of file changes with status and path
+
+### `M.parse_total_stats(file_stats_output)`
+
 Parse total statistics from `git diff --stat` output.
 Extracts the summary line (e.g., "5 files changed, 100 insertions(+), 20 deletions(-)").
-@param file_stats_output string The full `git diff --stat` output
-@return number total_files Number of files changed
-@return number total_insertions Total lines inserted
-@return number total_deletions Total lines deleted
 
+**Parameters:**
+
+- `file_stats_output` (`string`) — The full `git diff --stat` output
+
+**Returns:**
+
+- `number` — total_files Number of files changed
+- `number` — total_insertions Total lines inserted
+- `number` — total_deletions Total lines deleted
+
+## pr-description.links
+
+URL parsing and link generation for PR descriptions.
+
+Handles parsing of git remote URLs (SSH and HTTPS formats), building
+repository URLs, and generating markdown links for issues, Jira tickets,
+and commit references.
+
+### `M.parse_remote_url(url)`
+
+Parse a git remote URL into host and path components.
+Supports SSH (git@host:path or ssh://git@host/path) and HTTPS formats.
+
+**Parameters:**
+
+- `url` (`string`) — The git remote URL
+
+**Returns:**
+
+- `string|nil` — host The hostname (e.g., "github.com")
+- `string|nil` — path The repository path (e.g., "owner/repo")
+
+### `M.build_repo_url(host, path)`
+
+Build a full HTTPS repository URL from host and path.
+
+**Parameters:**
+
+- `host` (`string|nil`) — The hostname (e.g., "github.com")
+- `path` (`string|nil`) — The repository path (e.g., "owner/repo")
+
+**Returns:**
+
+- `string` — url The full repository URL, or empty string if host/path is nil
+
+### `M.is_gitlab_host(host)`
+
+Check if a host is a GitLab instance.
+
+**Parameters:**
+
+- `host` (`string|nil`) — The hostname to check
+
+**Returns:**
+
+- `boolean` — is_gitlab True if the host contains "gitlab"
+
+### `M.add_issue_links(text, repo_url, is_gitlab)`
+
+Add markdown links to issue references (e.g., "fixes #123").
+Converts patterns like "fixes #123" to "fixes [#123](repo_url/issues/123)".
+
+**Parameters:**
+
+- `text` (`string`) — The text to process
+- `repo_url` (`string`) — The repository base URL
+- `is_gitlab` (`boolean`) — Whether to use GitLab URL format (/-/issues/)
+
+**Returns:**
+
+- `string` — text The text with issue references converted to links
+
+### `M.add_jira_links(text, base_url)`
+
+Add markdown links to Jira ticket references (e.g., "PROJ-123").
+
+**Parameters:**
+
+- `text` (`string`) — The text to process
+- `base_url?` (`string`) — Jira base URL (e.g., "https://company.atlassian.net/browse")
+
+**Returns:**
+
+- `string` — text The text with Jira tickets converted to links
+
+### `M.add_all_links(text, repo_url, is_gitlab, jira_base_url)`
+
+Add all supported markdown links (issues and Jira tickets).
+
+**Parameters:**
+
+- `text` (`string`) — The text to process
+- `repo_url` (`string`) — The repository base URL
+- `is_gitlab` (`boolean`) — Whether to use GitLab URL format
+- `jira_base_url?` (`string`) — Jira base URL for ticket links
+
+**Returns:**
+
+- `string` — text The text with all references converted to links
+
+### `M.make_commit_link(hash, repo_url, is_gitlab)`
+
+Create a markdown link to a commit.
+
+**Parameters:**
+
+- `hash` (`string`) — The commit hash (short or full)
+- `repo_url` (`string`) — The repository base URL
+- `is_gitlab` (`boolean`) — Whether to use GitLab URL format (/-/commit/)
+
+**Returns:**
+
+- `string` — link The markdown link, or empty string if repo_url is empty
+
+## pr-description.formatter
+
+Markdown generation for PR descriptions.
+
+Formats categorized commits and file changes into a well-structured
+markdown document suitable for GitHub PRs or GitLab MRs. Includes
+emoji indicators, collapsible sections, and statistics.
+
+### `M.add_summary_section(lines)`
+
+Add the summary placeholder section to the output.
+
+**Parameters:**
+
+- `lines` (`string[]`) — The output lines table (modified in place)
+
+### `M.add_category_sections(lines, categories)`
+
+Add categorized commit sections to the output.
+Only adds sections for categories that have commits.
+
+**Parameters:**
+
+- `lines` (`string[]`) — The output lines table (modified in place)
+- `categories` (`CommitCategories`) — The categorized commits
+
+### `M.determine_file_group(filepath)`
+
+Determine which logical group a file belongs to based on its path.
+Groups files by top-level directory or special patterns (tests, docs, config).
+
+**Parameters:**
+
+- `filepath` (`string`) — The file path
+
+**Returns:**
+
+- `string` — group The group name (e.g., "Root", "Tests", "Documentation")
+
+### Type: `FileInfo`
+
+- `path` (`string`) — The file path
+- `symbol` (`string`) — Emoji status symbol
+- `stats` (`string`) — Formatted stats string (e.g., " (+10/-5)")
+
+### `M.group_files(file_list, file_stats)`
+
+Group files by their logical directory/category.
+
+**Parameters:**
+
+- `file_list` (`FileChange[]`) — List of file changes
+- `file_stats` (`table<string, FileStats>`) — Map of filepath to statistics
+
+**Returns:**
+
+- `table<string, FileInfo[]>` — groups Files grouped by category name
+
+### `M.sort_groups(groups)`
+
+Sort group names by predefined priority (Root first, Tests/Docs last).
+
+**Parameters:**
+
+- `groups` (`table<string, FileInfo[]>`) — The groups to sort
+
+**Returns:**
+
+- `string[]` — sorted_names Group names in sorted order
+
+### `M.add_file_changes_section(lines, file_groups, file_stats)`
+
+Add the file changes section to the output.
+Lists files grouped by category with statistics.
+
+**Parameters:**
+
+- `lines` (`string[]`) — The output lines table (modified in place)
+- `file_groups` (`table<string, FileInfo[]>`) — Files grouped by category
+- `file_stats` (`table<string, FileStats>`) — Map of filepath to statistics
+
+### Type: `DescriptionStats`
+
+- `total_files` (`number`) — Total number of files changed
+- `total_insertions` (`number`) — Total lines inserted
+- `total_deletions` (`number`) — Total lines deleted
+- `total_commits` (`number`) — Total number of commits
+- `branch` (`string`) — Current branch name
+- `base_branch` (`string`) — Base branch name
+
+### `M.add_footer(lines, stats)`
+
+Add the footer section with summary statistics.
+
+**Parameters:**
+
+- `lines` (`string[]`) — The output lines table (modified in place)
+- `stats` (`DescriptionStats`) — Summary statistics
+
+### `M.generate(categories, file_groups, file_stats, stats)`
+
+Generate the complete PR/MR description.
+
+**Parameters:**
+
+- `categories` (`CommitCategories`) — Categorized commits
+- `file_groups` (`table<string, FileInfo[]>`) — Files grouped by category
+- `file_stats` (`table<string, FileStats>`) — Map of filepath to statistics
+- `stats` (`DescriptionStats`) — Summary statistics
+
+**Returns:**
+
+- `string` — description The complete markdown description

--- a/doc/pr-description.txt
+++ b/doc/pr-description.txt
@@ -58,28 +58,28 @@ CONFIGURATION               *pr-description-pr-description.nvim-configuration*
     require("pr-description").setup({
       -- Auto-detect GitHub vs GitLab from remote URL (default: true)
       auto_detect_platform = true,
-    
+
       -- Prompt when more than `large_pr_threshold` commits (default: true)
       confirm_large_pr = true,
-    
+
       -- Include icons in final PR/MR pr-description (default: true)
       enable_icons = true,
-    
+
       -- Include stats footer in final PR/MR pr-description (default: true)
       enable_stats_footer = true,
-    
+
       -- Fetch origin before generating to ensure accurate comparison (default: true)
       fetch_before_generate = true,
-    
+
       -- Base URL for Jira ticket links (e.g., "https://company.atlassian.net/browse")
       jira_base_url = nil,
-    
+
       -- Number of commits before prompting (default: 10)
       large_pr_threshold = 10,
-    
+
       -- Override section headers (key = category, value = markdown header)
       sections = nil,
-    
+
       -- Strip conventional commit prefix/scope from output (default: true)
       strip_commit_prefix = true,
     })

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,14 +2,12 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },
         { "type": "perf", "section": "Performance" },
         { "type": "refactor", "section": "Refactoring" },
-        { "type": "docs", "section": "Documentation", "hidden": true },
+        { "type": "docs", "section": "Documentation" },
         { "type": "test", "section": "Tests", "hidden": true },
         { "type": "chore", "section": "Miscellaneous", "hidden": true }
       ]

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,28 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "enabledManagers": ["github-actions"]
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    ":semanticCommits",
+    ":dependencyDashboard",
+    "schedule:weekends"
+  ],
+  "enabledManagers": ["github-actions", "pre-commit"],
+  "pre-commit": {
+    "enabled": true
+  },
+  "minimumReleaseAge": "14 days",
+  "internalChecksFilter": "strict",
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "0 days"
+  },
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions", "pre-commit"],
+      "matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest"],
+      "automerge": true
+    }
+  ]
 }

--- a/scripts/generate-api-docs.lua
+++ b/scripts/generate-api-docs.lua
@@ -1,0 +1,295 @@
+#!/usr/bin/env lua
+--- Generates doc/api/README.md from the LuaCATS annotations in lua/pr-description/*.lua
+
+local script_dir = arg[0]:match("(.*/)") or "./"
+local repo_root = script_dir .. "../"
+local src_dir = repo_root .. "lua/pr-description/"
+local out_path = repo_root .. "doc/api/README.md"
+
+-- Modules in the order they should appear in the docs.
+local MODULE_ORDER = { "init", "config", "git", "parser", "links", "formatter" }
+
+local function read_file(path)
+  local f = assert(io.open(path, "r"))
+  local content = f:read("*a")
+  f:close()
+  return content
+end
+
+local function write_file(path, content)
+  local f = assert(io.open(path, "w"))
+  f:write(content)
+  f:close()
+end
+
+local function file_exists(path)
+  local f = io.open(path, "r")
+  if f then
+    f:close()
+    return true
+  end
+  return false
+end
+
+local function trim(s)
+  return (s:gsub("^%s*(.-)%s*$", "%1"))
+end
+
+-- Strip the leading "---" (and at most one following space) from an annotation line.
+local function strip_comment(line)
+  local body = line:match("^%s*%-%-%-?(.*)$")
+  if body == nil then
+    return nil
+  end
+  return (body:gsub("^ ", ""))
+end
+
+-- Split a "<type> <description>" string into type and description, where the
+-- type may contain balanced <...> or (...) (e.g. table<string, FileStats>).
+local function split_type_desc(s)
+  local depth = 0
+  local prev = ""
+  for k = 1, #s do
+    local c = s:sub(k, k)
+    if c == "<" or c == "(" then
+      depth = depth + 1
+    elseif c == ">" or c == ")" then
+      depth = depth - 1
+    elseif c == " " and depth == 0 and prev ~= ":" then
+      -- a depth-0 space ends the type, unless it directly follows a ":"
+      -- (e.g. the return part of `fun(x: string): string`)
+      return s:sub(1, k - 1), trim(s:sub(k + 1))
+    end
+    if c ~= " " then
+      prev = c
+    end
+  end
+  return s, ""
+end
+
+-- Read a source file into a list of "blocks". Each block is either:
+--   { kind = "comment", lines = {stripped...}, attached = "<fn signature>" | nil }
+-- A comment block is "attached" when the line immediately after it is a
+-- `function M.name(...)` declaration.
+local function parse_blocks(source)
+  local lines = {}
+  for line in (source .. "\n"):gmatch("(.-)\n") do
+    table.insert(lines, line)
+  end
+
+  local blocks = {}
+  local current = nil
+
+  local function flush(next_line)
+    if not current then
+      return
+    end
+    local fn_name, fn_args = (next_line or ""):match("^function%s+M%.([%w_]+)%s*(%b())")
+    if fn_name then
+      current.attached = "M." .. fn_name .. fn_args
+    end
+    table.insert(blocks, current)
+    current = nil
+  end
+
+  for _, line in ipairs(lines) do
+    if line:match("^%s*%-%-%-") then
+      current = current or { kind = "comment", lines = {} }
+      table.insert(current.lines, strip_comment(line))
+    else
+      flush(line)
+    end
+  end
+  flush(nil)
+
+  return blocks
+end
+
+-- Extract the module @brief prose (text between `@brief [[` and `@brief ]]`).
+local function extract_brief(blocks)
+  for _, block in ipairs(blocks) do
+    local capturing = false
+    local out = {}
+    for _, l in ipairs(block.lines) do
+      if l:match("^@brief%s*%[%[") then
+        capturing = true
+      elseif l:match("^@brief%s*%]%]") then
+        capturing = false
+      elseif capturing then
+        table.insert(out, l)
+      end
+    end
+    if #out > 0 then
+      -- drop leading/trailing blank lines
+      while out[1] == "" do
+        table.remove(out, 1)
+      end
+      while out[#out] == "" do
+        table.remove(out)
+      end
+      return table.concat(out, "\n")
+    end
+  end
+  return nil
+end
+
+-- Render a function block (a comment block with `attached` signature).
+local function render_function(block, out)
+  table.insert(out, "### `" .. block.attached .. "`")
+  table.insert(out, "")
+
+  local prose, params, returns = {}, {}, {}
+  for _, l in ipairs(block.lines) do
+    local param = l:match("^@param%s+(.*)$")
+    local ret = l:match("^@return%s+(.*)$")
+    if param then
+      local name, rest = param:match("^(%S+)%s*(.*)$")
+      local ptype, desc = split_type_desc(rest)
+      table.insert(params, { name = name, type = ptype, desc = desc })
+    elseif ret then
+      local rtype, desc = split_type_desc(ret)
+      table.insert(returns, { type = rtype, desc = desc })
+    elseif l:match("^@") then
+      -- ignore other annotations (@class, @type, etc.) inside function docs
+    else
+      table.insert(prose, l)
+    end
+  end
+
+  while prose[1] == "" do
+    table.remove(prose, 1)
+  end
+  while prose[#prose] == "" do
+    table.remove(prose)
+  end
+  if #prose > 0 then
+    table.insert(out, table.concat(prose, "\n"))
+    table.insert(out, "")
+  end
+
+  if #params > 0 then
+    table.insert(out, "**Parameters:**")
+    table.insert(out, "")
+    for _, p in ipairs(params) do
+      local line = "- `" .. p.name .. "` (`" .. p.type .. "`)"
+      if p.desc and p.desc ~= "" then
+        line = line .. " — " .. p.desc
+      end
+      table.insert(out, line)
+    end
+    table.insert(out, "")
+  end
+
+  if #returns > 0 then
+    table.insert(out, "**Returns:**")
+    table.insert(out, "")
+    for _, r in ipairs(returns) do
+      local line = "- `" .. r.type .. "`"
+      if r.desc and r.desc ~= "" then
+        line = line .. " — " .. r.desc
+      end
+      table.insert(out, line)
+    end
+    table.insert(out, "")
+  end
+end
+
+-- Render a standalone `@class` block as a type definition.
+local function render_class(block, out)
+  local name
+  local desc = {}
+  local fields = {}
+  for _, l in ipairs(block.lines) do
+    local cls = l:match("^@class%s+([%w_]+)")
+    local field = l:match("^@field%s+(.*)$")
+    if cls then
+      name = cls
+    elseif field then
+      local fname, rest = field:match("^(%S+)%s*(.*)$")
+      local ftype, fdesc = split_type_desc(rest)
+      table.insert(fields, { name = fname, type = ftype, desc = fdesc })
+    elseif not l:match("^@") and l ~= "" then
+      table.insert(desc, l)
+    end
+  end
+  if not name then
+    return false
+  end
+
+  table.insert(out, "### Type: `" .. name .. "`")
+  table.insert(out, "")
+  if #desc > 0 then
+    table.insert(out, table.concat(desc, "\n"))
+    table.insert(out, "")
+  end
+  for _, f in ipairs(fields) do
+    local line = "- `" .. f.name .. "` (`" .. f.type .. "`)"
+    if f.desc and f.desc ~= "" then
+      line = line .. " — " .. f.desc
+    end
+    table.insert(out, line)
+  end
+  table.insert(out, "")
+  return true
+end
+
+local function render_module(module, out)
+  local source = read_file(src_dir .. module .. ".lua")
+  local blocks = parse_blocks(source)
+
+  table.insert(out, "## pr-description." .. module)
+  table.insert(out, "")
+
+  local brief = extract_brief(blocks)
+  if brief then
+    table.insert(out, brief)
+    table.insert(out, "")
+  end
+
+  for _, block in ipairs(blocks) do
+    if block.attached then
+      render_function(block, out)
+    else
+      local has_class = false
+      for _, l in ipairs(block.lines) do
+        if l:match("^@class%s") then
+          has_class = true
+          break
+        end
+      end
+      if has_class then
+        render_class(block, out)
+      end
+    end
+  end
+end
+
+-- Main
+local out = {
+  "# API Reference",
+  "",
+  "Auto-generated from LuaCATS annotations. Do not edit by hand;",
+  "run `make docs` to regenerate.",
+  "",
+}
+
+for _, module in ipairs(MODULE_ORDER) do
+  if file_exists(src_dir .. module .. ".lua") then
+    render_module(module, out)
+  end
+end
+
+-- Trim trailing blank lines and ensure a single trailing newline.
+while out[#out] == "" do
+  table.remove(out)
+end
+local content = table.concat(out, "\n") .. "\n"
+
+local existing = file_exists(out_path) and read_file(out_path) or nil
+if existing == content then
+  print("doc/api/README.md is up to date")
+  os.exit(0)
+end
+
+write_file(out_path, content)
+print("doc/api/README.md updated")


### PR DESCRIPTION
## Summary

_Brief description of changes_

## ✨ Features
- Add `enable_stats_footer` option. Defaults to `true` (#18) [`3dd441e`](https://github.com/RemoteRabbit/pr-description.nvim/commit/3dd441e)
- Add toggle for description icons (#9) [`df739c6`](https://github.com/RemoteRabbit/pr-description.nvim/commit/df739c6)
- Setup releases (#5) [`9b1b636`](https://github.com/RemoteRabbit/pr-description.nvim/commit/9b1b636)

## 🐛 Bug Fixes
- Toggle for stripping prefix in description setup (#24) [`aeaa60b`](https://github.com/RemoteRabbit/pr-description.nvim/commit/aeaa60b)
- Adds git fetch call before generating desc. fallback to local ref (#21) [`e177b3f`](https://github.com/RemoteRabbit/pr-description.nvim/commit/e177b3f)
- Adds contents write permissions to vimdoc and luadoc workflows (#11) [`000ffb1`](https://github.com/RemoteRabbit/pr-description.nvim/commit/000ffb1)
- Don't use stylua action (#3) [`32462b4`](https://github.com/RemoteRabbit/pr-description.nvim/commit/32462b4)
- Update actions versions (#2) [`66a4cd2`](https://github.com/RemoteRabbit/pr-description.nvim/commit/66a4cd2)
- return boolean from is_breaking_change instead of match … (#1) [`2ec5df1`](https://github.com/RemoteRabbit/pr-description.nvim/commit/2ec5df1)

## 📚 Documentation
- auto-generate API reference (#25) [`4b962d6`](https://github.com/RemoteRabbit/pr-description.nvim/commit/4b962d6)
- auto-generate vimdoc (#26) [`bdedc93`](https://github.com/RemoteRabbit/pr-description.nvim/commit/bdedc93)
- auto-generate API reference (#22) [`e158831`](https://github.com/RemoteRabbit/pr-description.nvim/commit/e158831)
- auto-generate vimdoc (#20) [`b546204`](https://github.com/RemoteRabbit/pr-description.nvim/commit/b546204)
- auto-generate API reference (#19) [`af1619c`](https://github.com/RemoteRabbit/pr-description.nvim/commit/af1619c)
- auto-generate vimdoc (#15) [`70c094e`](https://github.com/RemoteRabbit/pr-description.nvim/commit/70c094e)
- auto-generate API reference (#14) [`e413cb5`](https://github.com/RemoteRabbit/pr-description.nvim/commit/e413cb5)
- Allow workflow to create docs pr (#13) [`597da66`](https://github.com/RemoteRabbit/pr-description.nvim/commit/597da66)

## 🔧 Maintenance
- Update docs and better renovate setup [`ef78b9a`](https://github.com/RemoteRabbit/pr-description.nvim/commit/ef78b9a)
- update googleapis/release-please-action action to v5 (#28) [`b695ea7`](https://github.com/RemoteRabbit/pr-description.nvim/commit/b695ea7)
- update leafo/gh-actions-lua action to v13 (#29) [`53e8521`](https://github.com/RemoteRabbit/pr-description.nvim/commit/53e8521)
- release 1.1.1 (#23) [`76fbca8`](https://github.com/RemoteRabbit/pr-description.nvim/commit/76fbca8)
- release 1.1.0 (#10) [`82c64a7`](https://github.com/RemoteRabbit/pr-description.nvim/commit/82c64a7)
- update peter-evans/create-pull-request action to v8 (#16) [`218ad24`](https://github.com/RemoteRabbit/pr-description.nvim/commit/218ad24)
- Setup base renovate for gha versions (#12) [`e198284`](https://github.com/RemoteRabbit/pr-description.nvim/commit/e198284)
- release 1.0.0 (#6) [`0c59ec0`](https://github.com/RemoteRabbit/pr-description.nvim/commit/0c59ec0)

## 📁 File Changes

### Root (+65/-4 lines)
- `.pre-commit-config.yaml` (+11/-2) 📝
- `.release-please-manifest.json` (+3) ✨
- `Makefile` (+6/-2) 📝
- `release-please-config.json` (+17) ✨
- `renovate.json` (+28) ✨

### .github (+161/-39 lines)
- `.github/ISSUE_TEMPLATE/bug_report.yml` (+60) ✨
- `.github/ISSUE_TEMPLATE/config.yml` (+5) ✨
- `.github/ISSUE_TEMPLATE/feature_request.yml` (+31) ✨
- `.github/workflows/docs.yml` (+36/-30) 📝
- `.github/workflows/release.yml` (+17) ✨
- `.github/workflows/test.yml` (+12/-9) 📝

### Lua (+205/-53 lines)
- `lua/pr-description/config.lua` (+10/-2) 📝
- `lua/pr-description/formatter.lua` (+41/-19) 📝
- `lua/pr-description/git.lua` (+71/-7) 📝
- `lua/pr-description/init.lua` (+25/-13) 📝
- `lua/pr-description/links.lua` (+8/-4) 📝
- `lua/pr-description/parser.lua` (+50/-8) 📝

### Plugin (+13/-24 lines)
- `plugin/pr-description.lua` (+13/-24) 📝

### Scripts (+412/-0 lines)
- `scripts/generate-api-docs.lua` (+295) ✨
- `scripts/update-readme-config.lua` (+117) ✨

### Tests (+1159/-2 lines)
- `tests/formatter_spec.lua` (+333) ✨
- `tests/git_spec.lua` (+216) ✨
- `tests/init_spec.lua` (+250) ✨
- `tests/integration_spec.lua` (+247) ✨
- `tests/links_spec.lua` (+52/-2) 📝
- `tests/parser_spec.lua` (+61) 📝

### Documentation (+887/-68 lines)
- `.github/pull_request_template.md` (+15) ✨
- `CHANGELOG.md` (+37) ✨
- `README.md` (+48/-5) 📝
- `doc/api/README.md` (+619) ✨
- `doc/pr-description.txt` (+168/-63) 📝

---

**Changes:** 31 files, +2902 insertions, -190 deletions
**Commits:** 25
**Branch:** `chore/update-docs-and-renovate`
**Base:** `origin/feat/initial-plugin-setup`