### PR TITLE
feat: Add small footer callback to link back to this plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ require("pr-description").setup({
   -- Include icons in final PR/MR pr-description (default: true)
   enable_icons = true,
 
+  -- Include a credit link to pr-description.nvim in the footer (default: true)
+  enable_plugin_credit = true,
+
   -- Include stats footer in final PR/MR pr-description (default: true)
   enable_stats_footer = true,
 

--- a/doc/api/README.md
+++ b/doc/api/README.md
@@ -52,6 +52,7 @@ Configuration for pr-description.nvim.
 - `auto_detect_platform?` (`boolean`) — Auto-detect GitHub vs GitLab from remote URL (default: true)
 - `confirm_large_pr?` (`boolean`) — Prompt when more than `large_pr_threshold` commits (default: true)
 - `enable_icons?` (`boolean`) — Include icons in final PR/MR pr-description (default: true)
+- `enable_plugin_credit?` (`boolean`) — Include a credit link to pr-description.nvim in the footer (default: true)
 - `enable_stats_footer?` (`boolean`) — Include stats footer in final PR/MR pr-description (default: true)
 - `fetch_before_generate?` (`boolean`) — Fetch origin before generating to ensure accurate comparison (default: true)
 - `jira_base_url?` (`string`) — Base URL for Jira ticket links (e.g., "https://company.atlassian.net/browse")
@@ -602,6 +603,14 @@ Add the footer section with summary statistics.
 
 - `lines` (`string[]`) — The output lines table (modified in place)
 - `stats` (`DescriptionStats`) — Summary statistics
+
+### `M.add_plugin_credit(lines)`
+
+Add a credit link back to pr-description.nvim.
+
+**Parameters:**
+
+- `lines` (`string[]`) — The output lines table (modified in place)
 
 ### `M.generate(categories, file_groups, file_stats, stats)`
 

--- a/lua/pr-description/config.lua
+++ b/lua/pr-description/config.lua
@@ -9,6 +9,7 @@ local M = {}
 ---@field auto_detect_platform? boolean Auto-detect GitHub vs GitLab from remote URL (default: true)
 ---@field confirm_large_pr? boolean Prompt when more than `large_pr_threshold` commits (default: true)
 ---@field enable_icons? boolean Include icons in final PR/MR pr-description (default: true)
+---@field enable_plugin_credit? boolean Include a credit link to pr-description.nvim in the footer (default: true)
 ---@field enable_stats_footer? boolean Include stats footer in final PR/MR pr-description (default: true)
 ---@field fetch_before_generate? boolean Fetch origin before generating to ensure accurate comparison (default: true)
 ---@field jira_base_url? string Base URL for Jira ticket links (e.g., "https://company.atlassian.net/browse")
@@ -21,6 +22,7 @@ M.defaults = {
   auto_detect_platform = true,
   confirm_large_pr = true,
   enable_icons = true,
+  enable_plugin_credit = true,
   enable_stats_footer = true,
   fetch_before_generate = true,
   jira_base_url = nil,

--- a/lua/pr-description/formatter.lua
+++ b/lua/pr-description/formatter.lua
@@ -254,6 +254,16 @@ function M.add_footer(lines, stats)
   table.insert(lines, "**Base:** `" .. stats.base_branch .. "`")
 end
 
+---Add a credit link back to pr-description.nvim.
+---@param lines string[] The output lines table (modified in place)
+function M.add_plugin_credit(lines)
+  table.insert(lines, "")
+  table.insert(
+    lines,
+    "<sub>_If you like this template check out the plugin [here](https://github.com/RemoteRabbit/pr-description.nvim)!_</sub>"
+  )
+end
+
 ---Generate the complete PR/MR description.
 ---@param categories CommitCategories Categorized commits
 ---@param file_groups table<string, FileInfo[]> Files grouped by category
@@ -266,8 +276,15 @@ function M.generate(categories, file_groups, file_stats, stats)
   M.add_summary_section(lines)
   M.add_category_sections(lines, categories)
   M.add_file_changes_section(lines, file_groups, file_stats)
-  if config.options.enable_stats_footer then
+  local has_footer = config.options.enable_stats_footer
+  if has_footer then
     M.add_footer(lines, stats)
+  end
+  if config.options.enable_plugin_credit then
+    if not has_footer then
+      table.insert(lines, "---")
+    end
+    M.add_plugin_credit(lines)
   end
 
   return table.concat(lines, "\n")

--- a/tests/formatter_spec.lua
+++ b/tests/formatter_spec.lua
@@ -329,5 +329,40 @@ describe("formatter", function()
       assert.falsy(result:find("**Branch:**", 1, true))
       assert.falsy(result:find("**Base:**", 1, true))
     end)
+
+    it("includes plugin credit by default", function()
+      local result = formatter.generate(
+        { features = { "- feat one" } },
+        { Root = { { path = "a.lua", symbol = " ✨", stats = " (+1)" } } },
+        { ["a.lua"] = { insertions = 1, deletions = 0 } },
+        default_stats
+      )
+      assert.truthy(result:find("check out the plugin", 1, true))
+      assert.truthy(result:find("https://github.com/RemoteRabbit/pr-description.nvim", 1, true))
+    end)
+
+    it("omits plugin credit when enable_plugin_credit is false", function()
+      reset_config({ enable_plugin_credit = false })
+      local result = formatter.generate(
+        { features = { "- feat one" } },
+        { Root = { { path = "a.lua", symbol = " ✨", stats = " (+1)" } } },
+        { ["a.lua"] = { insertions = 1, deletions = 0 } },
+        default_stats
+      )
+      assert.falsy(result:find("check out the plugin", 1, true))
+    end)
+
+    it("includes plugin credit with a separator when stats footer is disabled", function()
+      reset_config({ enable_stats_footer = false })
+      local result = formatter.generate(
+        { features = { "- feat one" } },
+        { Root = { { path = "a.lua", symbol = " ✨", stats = " (+1)" } } },
+        { ["a.lua"] = { insertions = 1, deletions = 0 } },
+        default_stats
+      )
+      assert.falsy(result:find("**Changes:**", 1, true))
+      assert.truthy(result:find("check out the plugin", 1, true))
+      assert.truthy(result:find("\n---\n", 1, true))
+    end)
   end)
 end)


### PR DESCRIPTION
## Summary

## ✨ Features
- Add small footer callback to link back to this plugin [`0426e6f`](https://github.com/RemoteRabbit/pr-description.nvim/commit/0426e6f)

## 📁 File Changes

### Lua (+20/-1 lines)
- `lua/pr-description/config.lua` (+2) 📝
- `lua/pr-description/formatter.lua` (+18/-1) 📝

### Tests (+35/-0 lines)
- `tests/formatter_spec.lua` (+35) 📝

### Documentation (+12/-0 lines)
- `README.md` (+3) 📝
- `doc/api/README.md` (+9) 📝

---

**Changes:** 5 files, +67 insertions, -1 deletions
**Commits:** 1
**Branch:** `feat/callback-plugin-footer`
**Base:** `origin/main`

<sub>_If you like this template check out the plugin [here](https://github.com/RemoteRabbit/pr-description.nvim)!_</sub>