### PR TITLE
feat: Autofold file change sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ require("pr-description").setup({
   -- Auto-detect GitHub vs GitLab from remote URL (default: true)
   auto_detect_platform = true,
 
+  -- Auto-fold a file change group when it has many files (default: true)
+  autofold = true,
+
+  -- Number of files in a group before it auto-folds (default: 10)
+  autofold_threshold = 10,
+
   -- Prompt when more than `large_pr_threshold` commits (default: true)
   confirm_large_pr = true,
 
@@ -53,6 +59,9 @@ require("pr-description").setup({
 
   -- Fetch origin before generating to ensure accurate comparison (default: true)
   fetch_before_generate = true,
+
+  -- Wrap each file change group in a collapsible <details> block (default: false)
+  foldable_file_changes = false,
 
   -- Base URL for Jira ticket links (e.g., "https://company.atlassian.net/browse")
   jira_base_url = nil,

--- a/doc/api/README.md
+++ b/doc/api/README.md
@@ -50,11 +50,14 @@ Configuration for pr-description.nvim.
 ### Type: `PrDescriptionConfig`
 
 - `auto_detect_platform?` (`boolean`) — Auto-detect GitHub vs GitLab from remote URL (default: true)
+- `autofold?` (`boolean`) — Auto-fold a file change group when it has many files (default: true)
+- `autofold_threshold?` (`number`) — Number of files in a group before it auto-folds (default: 10)
 - `confirm_large_pr?` (`boolean`) — Prompt when more than `large_pr_threshold` commits (default: true)
 - `enable_icons?` (`boolean`) — Include icons in final PR/MR pr-description (default: true)
 - `enable_plugin_credit?` (`boolean`) — Include a credit link to pr-description.nvim in the footer (default: true)
 - `enable_stats_footer?` (`boolean`) — Include stats footer in final PR/MR pr-description (default: true)
 - `fetch_before_generate?` (`boolean`) — Fetch origin before generating to ensure accurate comparison (default: true)
+- `foldable_file_changes?` (`boolean`) — Wrap each file change group in a collapsible <details> block (default: false)
 - `jira_base_url?` (`string`) — Base URL for Jira ticket links (e.g., "https://company.atlassian.net/browse")
 - `large_pr_threshold?` (`number`) — Number of commits before prompting (default: 10)
 - `sections?` (`table<string, string>`) — Override section headers (key = category, value = markdown header)
@@ -96,8 +99,10 @@ Get the name of the current git branch.
 ### `M.detect_base_branch()`
 
 Detect the base branch to compare against.
-Tries origin/HEAD first, then falls back to origin/main, origin/master,
-and finally local main/master branches.
+Tries origin/main, origin/master, then origin/HEAD (the remote's configured
+default), and finally local main/master branches. origin/HEAD is checked
+after the well-known names because it is set only at clone time and is
+frequently stale.
 
 **Returns:**
 

--- a/lua/pr-description/config.lua
+++ b/lua/pr-description/config.lua
@@ -7,11 +7,14 @@ local M = {}
 
 ---@class PrDescriptionConfig
 ---@field auto_detect_platform? boolean Auto-detect GitHub vs GitLab from remote URL (default: true)
+---@field autofold? boolean Auto-fold a file change group when it has many files (default: true)
+---@field autofold_threshold? number Number of files in a group before it auto-folds (default: 10)
 ---@field confirm_large_pr? boolean Prompt when more than `large_pr_threshold` commits (default: true)
 ---@field enable_icons? boolean Include icons in final PR/MR pr-description (default: true)
 ---@field enable_plugin_credit? boolean Include a credit link to pr-description.nvim in the footer (default: true)
 ---@field enable_stats_footer? boolean Include stats footer in final PR/MR pr-description (default: true)
 ---@field fetch_before_generate? boolean Fetch origin before generating to ensure accurate comparison (default: true)
+---@field foldable_file_changes? boolean Wrap each file change group in a collapsible <details> block (default: false)
 ---@field jira_base_url? string Base URL for Jira ticket links (e.g., "https://company.atlassian.net/browse")
 ---@field large_pr_threshold? number Number of commits before prompting (default: 10)
 ---@field sections? table<string, string> Override section headers (key = category, value = markdown header)
@@ -20,11 +23,14 @@ local M = {}
 ---@type PrDescriptionConfig
 M.defaults = {
   auto_detect_platform = true,
+  autofold = true,
+  autofold_threshold = 10,
   confirm_large_pr = true,
   enable_icons = true,
   enable_plugin_credit = true,
   enable_stats_footer = true,
   fetch_before_generate = true,
+  foldable_file_changes = false,
   jira_base_url = nil,
   large_pr_threshold = 10,
   sections = nil,

--- a/lua/pr-description/formatter.lua
+++ b/lua/pr-description/formatter.lua
@@ -201,10 +201,14 @@ function M.add_file_changes_section(lines, file_groups, file_stats)
   table.insert(lines, "")
 
   local sorted_groups = M.sort_groups(file_groups)
+  local fold_all = config.options.foldable_file_changes
+  local autofold = config.options.autofold
+  local autofold_threshold = config.options.autofold_threshold
 
   for _, group_name in ipairs(sorted_groups) do
     local files = file_groups[group_name]
     if files and #files > 0 then
+      local foldable = fold_all or (autofold and #files >= autofold_threshold)
       local group_insertions, group_deletions = 0, 0
 
       for _, file_info in ipairs(files) do
@@ -215,10 +219,23 @@ function M.add_file_changes_section(lines, file_groups, file_stats)
         end
       end
 
-      table.insert(lines, string.format("### %s (+%d/-%d lines)", group_name, group_insertions, group_deletions))
+      local heading = string.format("%s (+%d/-%d lines)", group_name, group_insertions, group_deletions)
+
+      if foldable then
+        table.insert(lines, "<details>")
+        table.insert(lines, string.format("<summary><b>%s</b></summary>", heading))
+        table.insert(lines, "")
+      else
+        table.insert(lines, "### " .. heading)
+      end
 
       for _, file_info in ipairs(files) do
         table.insert(lines, string.format("- `%s`%s%s", file_info.path, file_info.stats, file_info.symbol))
+      end
+
+      if foldable then
+        table.insert(lines, "")
+        table.insert(lines, "</details>")
       end
 
       table.insert(lines, "")

--- a/tests/formatter_spec.lua
+++ b/tests/formatter_spec.lua
@@ -243,6 +243,83 @@ describe("formatter", function()
       formatter.add_file_changes_section(lines, file_groups, file_stats)
       assert.equals("- `a.lua` (+3) ✨", lines[4])
     end)
+
+    it("wraps groups in collapsible blocks when foldable_file_changes is enabled", function()
+      reset_config({ foldable_file_changes = true })
+      local lines = {}
+      local file_groups = { Root = { { path = "a.lua", symbol = "", stats = " (+3)" } } }
+      local file_stats = { ["a.lua"] = { insertions = 3, deletions = 0 } }
+      formatter.add_file_changes_section(lines, file_groups, file_stats)
+      assert.equals("## 📁 File Changes", lines[1])
+      assert.equals("<details>", lines[3])
+      assert.equals("<summary><b>Root (+3/-0 lines)</b></summary>", lines[4])
+      assert.equals("", lines[5])
+      assert.equals("- `a.lua` (+3)", lines[6])
+      assert.equals("", lines[7])
+      assert.equals("</details>", lines[8])
+    end)
+
+    it("does not wrap groups when foldable_file_changes is disabled", function()
+      local lines = {}
+      local file_groups = { Root = { { path = "a.lua", symbol = "", stats = " (+3)" } } }
+      local file_stats = { ["a.lua"] = { insertions = 3, deletions = 0 } }
+      formatter.add_file_changes_section(lines, file_groups, file_stats)
+      assert.equals("### Root (+3/-0 lines)", lines[3])
+      assert.is_false(vim.tbl_contains(lines, "<details>"))
+    end)
+
+    ---Build a group with `n` files and a matching stats map.
+    ---@param n number
+    ---@return table, table
+    local function make_group(n)
+      local files, file_stats = {}, {}
+      for i = 1, n do
+        local path = string.format("f%d.lua", i)
+        table.insert(files, { path = path, symbol = "", stats = " (+1)" })
+        file_stats[path] = { insertions = 1, deletions = 0 }
+      end
+      return { Root = files }, file_stats
+    end
+
+    it("auto-folds a group at or above the threshold by default", function()
+      local lines = {}
+      local file_groups, file_stats = make_group(10)
+      formatter.add_file_changes_section(lines, file_groups, file_stats)
+      assert.is_true(vim.tbl_contains(lines, "<details>"))
+      assert.is_true(vim.tbl_contains(lines, "<summary><b>Root (+10/-0 lines)</b></summary>"))
+    end)
+
+    it("does not auto-fold a group below the threshold", function()
+      local lines = {}
+      local file_groups, file_stats = make_group(9)
+      formatter.add_file_changes_section(lines, file_groups, file_stats)
+      assert.is_false(vim.tbl_contains(lines, "<details>"))
+      assert.equals("### Root (+9/-0 lines)", lines[3])
+    end)
+
+    it("respects a custom autofold_threshold", function()
+      reset_config({ autofold_threshold = 3 })
+      local lines = {}
+      local file_groups, file_stats = make_group(3)
+      formatter.add_file_changes_section(lines, file_groups, file_stats)
+      assert.is_true(vim.tbl_contains(lines, "<details>"))
+    end)
+
+    it("does not auto-fold when autofold is disabled", function()
+      reset_config({ autofold = false })
+      local lines = {}
+      local file_groups, file_stats = make_group(20)
+      formatter.add_file_changes_section(lines, file_groups, file_stats)
+      assert.is_false(vim.tbl_contains(lines, "<details>"))
+    end)
+
+    it("folds all groups when foldable_file_changes is set even if autofold is off", function()
+      reset_config({ autofold = false, foldable_file_changes = true })
+      local lines = {}
+      local file_groups, file_stats = make_group(1)
+      formatter.add_file_changes_section(lines, file_groups, file_stats)
+      assert.is_true(vim.tbl_contains(lines, "<details>"))
+    end)
   end)
 
   describe("add_footer", function()


### PR DESCRIPTION
## Summary

Closes #30 

## ✨ Features
- Add autofold file change sections with extra toggles [`0c87c10`](https://github.com/RemoteRabbit/pr-description.nvim/commit/0c87c10)

## 📁 File Changes

### Lua (+24/-1 lines)
- `lua/pr-description/config.lua` (+6) 📝
- `lua/pr-description/formatter.lua` (+18/-1) 📝

### Tests (+77/-0 lines)
- `tests/formatter_spec.lua` (+77) 📝

### Documentation (+16/-2 lines)
- `README.md` (+9) 📝
- `doc/api/README.md` (+7/-2) 📝

---

**Changes:** 5 files, +117 insertions, -3 deletions
**Commits:** 1
**Branch:** `feat/auto-fold-files`
**Base:** `origin/main`

<sub>_If you like this template check out the plugin [here](https://github.com/RemoteRabbit/pr-description.nvim)!_</sub>